### PR TITLE
[codex] Add Elixir 1.20 CI support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,6 +18,8 @@ jobs:
           elixir: '1.18.4'
         - otp: '28'
           elixir: '1.19.5'
+        - otp: '28'
+          elixir: '1.20.0'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/lib/typespec.ex
+++ b/lib/typespec.ex
@@ -96,9 +96,6 @@ defmodule Strukt.Typespec do
   defp map(elements) when is_list(elements),
     do: {:%{}, [], elements}
 
-  defp map(elements) when is_map(elements),
-    do: {:%{}, [], Map.to_list(elements)}
-
   defp compose_call(module, function, args) when is_atom(module) and is_list(args),
     do: {{:., [], [{:__aliases__, [alias: false], [module]}, function]}, [], args}
 


### PR DESCRIPTION
## Summary

- add Elixir 1.20.0 to the CI matrix while keeping existing supported versions
- remove an unreachable private `map/1` clause exposed by Elixir 1.20 warning analysis

## Validation

- `mix deps.get`
- `mix compile --warnings-as-errors --force`
- `mix test` (`35 passed`)

## Notes

Local validation ran on Elixir 1.20.0 / OTP 29. The new CI matrix entry uses Elixir 1.20.0 / OTP 28.