### PR TITLE
Preserve invalid scalar embed params

### DIFF
--- a/lib/params.ex
+++ b/lib/params.ex
@@ -10,6 +10,12 @@ defmodule Strukt.Params do
       when is_map(params) and map_size(params) == 0,
       do: params
 
+  # Scalar params have no fields to map. Preserve them so Ecto can report the type mismatch
+  # instead of crashing in get_params_field_value/3.
+  def transform(_module, params, _struct)
+      when not is_map(params) and not is_list(params) and not is_nil(params),
+      do: params
+
   def transform(module, params, nil = _struct) when is_struct(params) do
     transform_from_struct(module, params, params)
   end

--- a/test/strukt_test.exs
+++ b/test/strukt_test.exs
@@ -499,6 +499,32 @@ defmodule Strukt.Test do
       })
   end
 
+  test "return error when an embeds_many item has the wrong type" do
+    assert {:error,
+            %Ecto.Changeset{
+              action: :insert,
+              changes: %{},
+              errors: [items: {"is invalid", [validation: :embed, type: {:array, :map}]}],
+              valid?: false
+            }} =
+             Fixtures.CustomFieldsWithEmbeddedSchema.new(%{
+               items: ["item"]
+             })
+  end
+
+  test "return error when passing wrong typed value to embeds_one field" do
+    assert {:error,
+            %Ecto.Changeset{
+              action: :insert,
+              changes: %{},
+              errors: [meta: {"is invalid", [validation: :embed, type: :map]}],
+              valid?: false
+            }} =
+             Fixtures.CustomFieldsWithEmbeddedSchema.new(%{
+               meta: "metadata"
+             })
+  end
+
   test "parse custom fields with boolean value" do
     assert {:ok, %Strukt.Test.Fixtures.CustomFieldsWithBoolean{enabled: false, uuid: uuid}} =
              Fixtures.CustomFieldsWithBoolean.new(%{Enabled: false})


### PR DESCRIPTION
## What changed

- Preserve scalar params during schema transformation so Ecto can handle invalid embed input.
- Add regression coverage for a scalar item inside `embeds_many`.
- Add regression coverage for a scalar value passed to `embeds_one`.

## Why

A scalar item supplied to an embedded schema has no fields to map. It previously fell through to `transform_from_struct/3`, where `get_params_field_value/3` crashed before Ecto could validate the input.

Returning the scalar unchanged allows `cast_embed` to produce the expected type validation error instead of raising.

## Impact

Invalid scalar values for `embeds_one` and scalar elements inside `embeds_many` now return normal changeset errors.

## Validation

- `mix format --check-formatted lib/params.ex test/strukt_test.exs`
- `mix test test/strukt_test.exs` — 51 tests passed
- `git diff --check`